### PR TITLE
Swap demo intents to Add Beneficiary + Credit Limit Increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deterministic Stateful Agent with Async Human-in-the-Loop
 
-A reference implementation of a **deterministic, stage-driven LangGraph agent** that pauses for an **asynchronous human-in-the-loop (HIL) step** and resumes automatically when the external result arrives. The reference domain is a **private banking assistant** (account statements, opening deposits, AML-style background checks), but the underlying pattern applies to any regulated workflow that combines LLM-powered natural language handling with deterministic business logic and long-running external dependencies.
+A reference implementation of a **deterministic, stage-driven LangGraph agent** that pauses for an **asynchronous human-in-the-loop (HIL) step** and resumes automatically when the external result arrives. The reference domain is a **private banking assistant** (adding beneficiaries, credit-limit-increase requests, AML-style background checks), but the underlying pattern applies to any regulated workflow that combines LLM-powered natural language handling with deterministic business logic and long-running external dependencies.
 
 ## Why this exists
 
@@ -49,10 +49,10 @@ For a full state-machine diagram and stage-by-stage walkthrough see [`agent_app/
 
 ## Reference implementation: private banking
 
-The included demo implements a private-banking assistant with two intents:
+The included demo implements a private-banking assistant with two intents. Both run the same flow: collect the required fields, then **submit a mandatory background check (async HIL)**; wait; on approval render an email and send; on denial terminate the workflow.
 
-- `GENERATE_ACCOUNT_STATEMENT` — collect `customer_id`, `account_id`, period dates; render an email; send.
-- `OPEN_DEPOSIT` — collect `customer_id`, `amount`, `currency`, `term_months`, `payout_account`; **submit a mandatory background check (async HIL)**; wait; on approval render email and send; on denial terminate the workflow.
+- `ADD_BENEFICIARY` — collect `customer_id`, `beneficiary_name`, `beneficiary_account`, `sort_code`.
+- `REQUEST_CREDIT_LIMIT_INCREASE` — collect `customer_id`, `card_id`, `amount`, `currency`, `reason`.
 
 An 8-stage state machine (`START → CLASSIFY_INTENT → GET_TEMPLATE → ASK_FOR_FIELDS ↔ EXTRACT_FIELDS → LOOKUP_CUSTOMER_EMAIL → CUSTOMER_BACKGROUND_CHECK → WAITING_FOR_BACKGROUND_CHECK → CONFIRM → SEND_EMAIL → DONE`) drives the UI's step-progress badge and filter controls.
 

--- a/agent_app/agent_server/README.md
+++ b/agent_app/agent_server/README.md
@@ -96,7 +96,7 @@ The state is a `TypedDict` with the following fields:
 | ------------------ | ---------------- | ------------------------------------------------------------------ |
 | `messages`         | `list`           | Conversation history (uses LangGraph's `add_messages` reducer)     |
 | `stage`            | `str`            | Current workflow stage (drives all routing)                        |
-| `intent`           | `str`            | Classified intent (`GENERATE_ACCOUNT_STATEMENT` or `OPEN_DEPOSIT`) |
+| `intent`           | `str`            | Classified intent (`ADD_BENEFICIARY` or `REQUEST_CREDIT_LIMIT_INCREASE`) |
 | `required_fields`  | `list[str]`      | Fields required by the selected template                           |
 | `field_values`     | `dict[str, str]` | Collected field values so far                                      |
 | `missing_fields`   | `list[str]`      | Fields still needed from the user                                  |
@@ -116,8 +116,8 @@ The state is a `TypedDict` with the following fields:
 
 ### Supported intents
 
-- `**GENERATE_ACCOUNT_STATEMENT**` — requires `customer_id`, `account_id`, `period_start`, `period_end`
-- `**OPEN_DEPOSIT**` — requires `customer_id`, `amount`, `currency`, `term_months`, `payout_account`
+- `**ADD_BENEFICIARY**` — requires `customer_id`, `beneficiary_name`, `beneficiary_account`, `sort_code`
+- `**REQUEST_CREDIT_LIMIT_INCREASE**` — requires `customer_id`, `card_id`, `amount`, `currency`, `reason`
 
 ## LLM vs. stub duality
 
@@ -126,7 +126,7 @@ The state is a `TypedDict` with the following fields:
 
 | Capability             | With LLM                                                              | Without LLM (stubs only)                                              |
 | ---------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Intent classification  | `_llm_classify_intent` — LLM returns JSON with intent                 | `classify_intent` stub — substring matching ("statement" / "deposit") |
+| Intent classification  | `_llm_classify_intent` — LLM returns JSON with intent                 | `classify_intent` stub — substring matching ("beneficiary"/"payee" / "credit"/"limit") |
 | Field extraction       | `_llm_extract_fields` — LLM parses natural language into field values | `extract_fields` stub — regex `key=value` / JSON parsing              |
 | Message classification | `_llm_classify_message` — LLM decides question vs. workflow data      | Always returns `False` (treat everything as workflow data)            |
 | User-facing responses  | `_llm_generate_response` — LLM generates natural-language replies     | `_format_status_preamble` — deterministic field checklist             |
@@ -141,7 +141,7 @@ Every function in `tools_stubs.py` accepts a `scenario` keyword argument (defaul
 
 | Tool                                                | What it does                                                     |
 | --------------------------------------------------- | ---------------------------------------------------------------- |
-| `classify_intent(text)`                             | Substring-based intent detection (statement / deposit / unknown) |
+| `classify_intent(text)`                             | Substring-based intent detection (beneficiary / credit limit / unknown) |
 | `get_template(intent)`                              | Returns template with `required_fields` and `template_body`      |
 | `extract_fields(text, required_fields)`             | Parses `key=value` pairs or JSON from user text                  |
 | `lookup_customer_email(customer_id)`                | Returns a fake email address                                     |
@@ -168,7 +168,7 @@ Scenarios let tests exercise every error and edge-case branch without mocking.
 
 ## Async background check flow
 
-The `OPEN_DEPOSIT` workflow includes a mandatory background check that pauses the graph and resumes asynchronously when an external system delivers the result. The external system POSTs the result to `/invocations`; the handler writes it into the Lakebase checkpoint via `graph.aupdate_state()` and fires an **internal webhook** to the chat UI.
+The `REQUEST_CREDIT_LIMIT_INCREASE` workflow includes a mandatory background check that pauses the graph and resumes asynchronously when an external system delivers the result. The external system POSTs the result to `/invocations`; the handler writes it into the Lakebase checkpoint via `graph.aupdate_state()` and fires an **internal webhook** to the chat UI.
 
 ```mermaid
 sequenceDiagram
@@ -296,12 +296,12 @@ The tests use LangGraph's `MemorySaver` as the checkpointer instead of `AsyncChe
 
 | Test                                           | What it verifies                                                                                         |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `test_happy_path`                              | Full account-statement flow: classify intent, provide all fields, confirm, send                          |
+| `test_happy_path`                              | Full add-beneficiary flow: classify intent, provide all fields, confirm, send                            |
 | `test_missing_fields_loop`                     | Partial fields trigger re-ask; providing remaining fields advances the workflow                          |
 | `test_confirmation_gating`                     | Sending field changes instead of "SEND" at the preview stage does not trigger email delivery             |
 | `test_natural_confirm_words`                   | Confirmation phrases like "go ahead", "ok", "sure", "looks good" all trigger send                        |
 | `test_change_customer_id_at_send_email`        | Changing `customer_id` at the preview stage re-looks up the email address                                |
-| `test_open_deposit_incremental_fields`         | `OPEN_DEPOSIT` flow with fields provided across multiple turns                                           |
+| `test_credit_limit_incremental_fields`         | `REQUEST_CREDIT_LIMIT_INCREASE` flow with fields provided across multiple turns                          |
 | `test_change_non_customer_field_at_send_email` | Changing a non-identity field (e.g. `amount`) at preview updates the preview without re-looking up email |
 | `test_background_check_happy_path`             | Full flow: submit background check, wait, inject approved result, resume to CONFIRM and complete         |
 | `test_background_check_waiting_blocks_user`    | User messages while in `WAITING_FOR_BACKGROUND_CHECK` do not advance the workflow                        |

--- a/agent_app/agent_server/dev_smoke_test.py
+++ b/agent_app/agent_server/dev_smoke_test.py
@@ -44,25 +44,25 @@ async def _inject_background_check(graph, config, status="approved"):
 
 
 async def test_happy_path() -> None:
-    """Full account-statement flow: classify -> fields -> bg check -> confirm -> send."""
+    """Full add-beneficiary flow: classify -> fields -> bg check -> confirm -> send."""
     print("=== Happy path ===")
     graph = build_graph(checkpointer=MemorySaver())
     config = {"configurable": {"thread_id": "happy-1"}}
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS", f"Expected EXTRACT_FIELDS, got {state['stage']}"
-    assert state["intent"] == "GENERATE_ACCOUNT_STATEMENT"
+    assert state["intent"] == "ADD_BENEFICIARY"
     print(f"  Turn 1  stage={state['stage']}")
 
     # Turn 2: provide all fields -> background check submitted, graph pauses
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C001 account_id=A100 period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C001 beneficiary_name=JaneDoe beneficiary_account=BEN100 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -100,26 +100,26 @@ async def test_missing_fields_loop() -> None:
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("I need an account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("I want to add a payee"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS"
     assert len(state["missing_fields"]) == 4
     print(f"  Turn 1  stage={state['stage']}  missing={state['missing_fields']}")
 
-    # Turn 2: partial -- only customer_id and account_id
+    # Turn 2: partial -- only customer_id and beneficiary_name
     state = await graph.ainvoke(
-        {**_user_msg("customer_id=C002 account_id=A200"), "stub_scenario": "happy_path"},
+        {**_user_msg("customer_id=C002 beneficiary_name=JohnDoe"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS", f"Expected EXTRACT_FIELDS, got {state['stage']}"
-    assert set(state["missing_fields"]) == {"period_start", "period_end"}
+    assert set(state["missing_fields"]) == {"beneficiary_account", "sort_code"}
     print(f"  Turn 2  stage={state['stage']}  missing={state['missing_fields']}")
 
     # Turn 3: provide remaining fields -> waiting for background check
     state = await graph.ainvoke(
         {
-            **_user_msg("period_start=2025-01-01 period_end=2025-06-30"),
+            **_user_msg("beneficiary_account=BEN200 sort_code=11-22-33"),
             "stub_scenario": "happy_path",
         },
         config,
@@ -153,7 +153,7 @@ async def test_confirmation_gating() -> None:
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
 
@@ -161,7 +161,7 @@ async def test_confirmation_gating() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C003 account_id=A300 period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C003 beneficiary_name=JaneDoe beneficiary_account=BEN300 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -176,13 +176,13 @@ async def test_confirmation_gating() -> None:
 
     # Turn 4: change a field instead of confirming -> triggers new background check
     state = await graph.ainvoke(
-        {**_user_msg("period_end=2025-06-30"), "stub_scenario": "happy_path"},
+        {**_user_msg("sort_code=99-88-77"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] != "DONE", "Graph must NOT send when user specifies changes"
-    assert state["field_values"]["period_end"] == "2025-06-30"
+    assert state["field_values"]["sort_code"] == "99-88-77"
     print(
-        f"  Turn 4  stage={state['stage']}  period_end={state['field_values']['period_end']}"
+        f"  Turn 4  stage={state['stage']}  sort_code={state['field_values']['sort_code']}"
         f"  (change accepted, not sent)"
     )
 
@@ -210,7 +210,7 @@ async def test_natural_confirm_words() -> None:
 
         # Turn 1: intent
         await graph.ainvoke(
-            {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+            {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
             config,
         )
 
@@ -218,8 +218,8 @@ async def test_natural_confirm_words() -> None:
         state = await graph.ainvoke(
             {
                 **_user_msg(
-                    "customer_id=C010 account_id=A110 "
-                    "period_start=2025-01-01 period_end=2025-12-31"
+                    "customer_id=C010 beneficiary_name=JaneDoe "
+                    "beneficiary_account=BEN110 sort_code=20-30-40"
                 ),
                 "stub_scenario": "happy_path",
             },
@@ -256,7 +256,7 @@ async def test_change_customer_id_at_send_email() -> None:
 
     # Turn 1: intent
     await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
 
@@ -264,8 +264,8 @@ async def test_change_customer_id_at_send_email() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C001 account_id=A100 "
-                "period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C001 beneficiary_name=JaneDoe "
+                "beneficiary_account=BEN100 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -307,38 +307,38 @@ async def test_change_customer_id_at_send_email() -> None:
     print("  PASSED\n")
 
 
-async def test_open_deposit_incremental_fields() -> None:
-    """OPEN_DEPOSIT: provide fields incrementally and reach email preview."""
-    print("=== Open deposit incremental fields ===")
+async def test_credit_limit_incremental_fields() -> None:
+    """REQUEST_CREDIT_LIMIT_INCREASE: provide fields incrementally and reach email preview."""
+    print("=== Credit limit incremental fields ===")
     graph = build_graph(checkpointer=MemorySaver())
-    config = {"configurable": {"thread_id": "deposit-1"}}
+    config = {"configurable": {"thread_id": "creditlimit-1"}}
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("I want to open a deposit"), "stub_scenario": "happy_path"},
+        {**_user_msg("I want to request a credit limit increase"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS", f"Expected EXTRACT_FIELDS, got {state['stage']}"
-    assert state["intent"] == "OPEN_DEPOSIT"
+    assert state["intent"] == "REQUEST_CREDIT_LIMIT_INCREASE"
     assert len(state["missing_fields"]) == 5
     print(f"  Turn 1  stage={state['stage']}  missing={state['missing_fields']}")
 
-    # Turn 2: partial -- customer_id, amount, currency
+    # Turn 2: partial -- customer_id, card_id, amount
     state = await graph.ainvoke(
         {
-            **_user_msg("customer_id=C100 amount=5000 currency=EUR"),
+            **_user_msg("customer_id=C100 card_id=CARD1 amount=5000"),
             "stub_scenario": "happy_path",
         },
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS", f"Expected EXTRACT_FIELDS, got {state['stage']}"
-    assert set(state["missing_fields"]) == {"term_months", "payout_account"}
+    assert set(state["missing_fields"]) == {"currency", "reason"}
     print(f"  Turn 2  stage={state['stage']}  missing={state['missing_fields']}")
 
     # Turn 3: provide remaining fields -> waiting
     state = await graph.ainvoke(
         {
-            **_user_msg("term_months=12 payout_account=ACC999"),
+            **_user_msg("currency=EUR reason=Travel"),
             "stub_scenario": "happy_path",
         },
         config,
@@ -374,7 +374,7 @@ async def test_change_non_customer_field_at_send_email() -> None:
 
     # Turn 1: intent
     await graph.ainvoke(
-        {**_user_msg("I want to open a deposit"), "stub_scenario": "happy_path"},
+        {**_user_msg("I want to request a credit limit increase"), "stub_scenario": "happy_path"},
         config,
     )
 
@@ -382,8 +382,8 @@ async def test_change_non_customer_field_at_send_email() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C100 amount=5000 currency=EUR "
-                "term_months=12 payout_account=ACC999"
+                "customer_id=C100 card_id=CARD1 amount=5000 "
+                "currency=EUR reason=Travel"
             ),
             "stub_scenario": "happy_path",
         },
@@ -438,7 +438,7 @@ async def test_background_check_happy_path() -> None:
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS"
@@ -448,8 +448,8 @@ async def test_background_check_happy_path() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C050 account_id=A500 "
-                "period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C050 beneficiary_name=JaneDoe "
+                "beneficiary_account=BEN500 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -487,7 +487,7 @@ async def test_background_check_waiting_blocks_user() -> None:
 
     # Turn 1: intent
     await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
 
@@ -495,8 +495,8 @@ async def test_background_check_waiting_blocks_user() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C060 account_id=A600 "
-                "period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C060 beneficiary_name=JaneDoe "
+                "beneficiary_account=BEN600 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -532,7 +532,7 @@ async def test_background_check_denied() -> None:
 
     # Turn 1: intent
     state = await graph.ainvoke(
-        {**_user_msg("Generate account statement"), "stub_scenario": "happy_path"},
+        {**_user_msg("Add a new beneficiary"), "stub_scenario": "happy_path"},
         config,
     )
     assert state["stage"] == "EXTRACT_FIELDS"
@@ -542,8 +542,8 @@ async def test_background_check_denied() -> None:
     state = await graph.ainvoke(
         {
             **_user_msg(
-                "customer_id=C070 account_id=A700 "
-                "period_start=2025-01-01 period_end=2025-12-31"
+                "customer_id=C070 beneficiary_name=JaneDoe "
+                "beneficiary_account=BEN700 sort_code=20-30-40"
             ),
             "stub_scenario": "happy_path",
         },
@@ -585,7 +585,7 @@ async def _run_all() -> None:
     await test_confirmation_gating()
     await test_natural_confirm_words()
     await test_change_customer_id_at_send_email()
-    await test_open_deposit_incremental_fields()
+    await test_credit_limit_incremental_fields()
     await test_change_non_customer_field_at_send_email()
     await test_background_check_happy_path()
     await test_background_check_waiting_blocks_user()

--- a/agent_app/agent_server/langgraph_agent.py
+++ b/agent_app/agent_server/langgraph_agent.py
@@ -63,8 +63,8 @@ class WorkflowState(TypedDict):
 # ---------------------------------------------------------------------------
 
 _INTENT_LABELS: dict[str, str] = {
-    "GENERATE_ACCOUNT_STATEMENT": "Account Statement",
-    "OPEN_DEPOSIT": "Open Deposit",
+    "ADD_BENEFICIARY": "Add Beneficiary",
+    "REQUEST_CREDIT_LIMIT_INCREASE": "Credit Limit Increase",
 }
 
 _STAGE_STEP: dict[str, int] = {
@@ -113,7 +113,7 @@ _CONFIRM_WORDS = frozenset({
 })
 
 _STAGE_EXPECTATIONS: dict[str, str] = {
-    "EXTRACT_FIELDS": "field values for the banking workflow (e.g. customer_id, amounts, dates)",
+    "EXTRACT_FIELDS": "field values for the banking workflow (e.g. customer_id, beneficiary or card details, amounts)",
     "SEND_EMAIL": "explicit confirmation to send (e.g. 'SEND', 'yes') or field changes",
     "WAITING_FOR_BACKGROUND_CHECK": "no user input expected; waiting for an external background check result",
     "DENIED": "the background check was denied; the workflow is permanently terminated",
@@ -150,11 +150,11 @@ _STAGE_INSTRUCTIONS: dict[str, str] = {
     ),
     "CLASSIFY_INTENT": (
         "The user's request does not match any supported operation. "
-        "You can ONLY help with: (1) generating account statements, or "
-        "(2) opening deposits. You CANNOT help with anything else — do NOT "
-        "pretend you can handle unsupported requests such as money transfers, "
-        "payments, loan applications, or any other banking operation. "
-        "Politely explain what you CAN do and ask the user to choose."
+        "You can ONLY help with: (1) adding a new beneficiary / payee, or "
+        "(2) requesting a credit limit increase. You CANNOT help with anything "
+        "else — do NOT pretend you can handle unsupported requests such as "
+        "money transfers, payments, loan applications, or any other banking "
+        "operation. Politely explain what you CAN do and ask the user to choose."
     ),
     "WAITING_FOR_BACKGROUND_CHECK": (
         "A mandatory background check is currently in progress. The user "
@@ -261,10 +261,10 @@ async def _llm_classify_intent(llm: Any, text: str) -> dict[str, Any]:
     system = (
         "You are a banking assistant. Classify the user's intent.\n\n"
         "Possible intents:\n"
-        "- GENERATE_ACCOUNT_STATEMENT: user wants to generate or receive an account statement\n"
-        "- OPEN_DEPOSIT: user wants to open a new deposit\n\n"
+        "- ADD_BENEFICIARY: user wants to add a new beneficiary / payee\n"
+        "- REQUEST_CREDIT_LIMIT_INCREASE: user wants to request a higher credit limit\n\n"
         "If the message doesn't clearly match either intent, return UNKNOWN.\n\n"
-        'Return ONLY a JSON object, e.g.: {"intent": "OPEN_DEPOSIT"}'
+        'Return ONLY a JSON object, e.g.: {"intent": "REQUEST_CREDIT_LIMIT_INCREASE"}'
     )
     try:
         response = await llm.ainvoke([SystemMessage(content=system), HumanMessage(content=text)])
@@ -303,8 +303,8 @@ async def _llm_extract_fields(
         "CRITICAL: You MUST use EXACTLY the field names listed above as JSON "
         "keys. Do NOT invent your own key names or use synonyms. Map the "
         "user's natural language to the exact required field name. For example, "
-        "if the required field is 'term_months', use 'term_months' as the key "
-        "even if the user says 'term length', 'duration', or 'months'.\n\n"
+        "if the required field is 'sort_code', use 'sort_code' as the key "
+        "even if the user says 'sort code', 'branch code', or 'routing'.\n\n"
         "Return ONLY a JSON object with field names as keys and extracted values "
         "as strings. If the message contains no field values, return {}."
     )
@@ -369,8 +369,8 @@ async def _llm_generate_response(llm: Any, state: WorkflowState) -> str:
 
     system = (
         "You are a friendly banking assistant.\n"
-        "You can ONLY help with two operations: generating account statements "
-        "and opening deposits. You have NO other capabilities. NEVER offer to "
+        "You can ONLY help with two operations: adding a new beneficiary / payee "
+        "and requesting a credit limit increase. You have NO other capabilities. NEVER offer to "
         "help with operations you cannot perform.\n\n"
         + role_instruction
         + "\n\nCurrent state:\n"
@@ -759,7 +759,7 @@ def build_graph(checkpointer=None, llm=None):
         if llm:
             parsed = await _llm_classify_intent(llm, text)
             intent = parsed.get("intent", "").upper()
-            if intent in ("GENERATE_ACCOUNT_STATEMENT", "OPEN_DEPOSIT"):
+            if intent in ("ADD_BENEFICIARY", "REQUEST_CREDIT_LIMIT_INCREASE"):
                 new_stage = "GET_TEMPLATE"
                 return {
                     "stage": new_stage,

--- a/agent_app/agent_server/tools_stubs.py
+++ b/agent_app/agent_server/tools_stubs.py
@@ -23,10 +23,10 @@ def classify_intent(text: str, *, scenario: str = "happy_path") -> dict[str, Any
         return {"intent": "UNKNOWN", "confidence": 0.0}
 
     lower = text.lower()
-    if "statement" in lower:
-        intent = "GENERATE_ACCOUNT_STATEMENT"
-    elif "deposit" in lower:
-        intent = "OPEN_DEPOSIT"
+    if "beneficiary" in lower or "payee" in lower:
+        intent = "ADD_BENEFICIARY"
+    elif "credit" in lower or "limit" in lower:
+        intent = "REQUEST_CREDIT_LIMIT_INCREASE"
     else:
         intent = "UNKNOWN"
 
@@ -39,47 +39,49 @@ def classify_intent(text: str, *, scenario: str = "happy_path") -> dict[str, Any
 # ---------------------------------------------------------------------------
 
 _TEMPLATES: dict[str, dict[str, Any]] = {
-    "GENERATE_ACCOUNT_STATEMENT": {
-        "template_id": "tmpl-account-statement-v1",
+    "ADD_BENEFICIARY": {
+        "template_id": "tmpl-add-beneficiary-v1",
         "required_fields": [
             "customer_id",
-            "account_id",
-            "period_start",
-            "period_end",
+            "beneficiary_name",
+            "beneficiary_account",
+            "sort_code",
         ],
         "template_body": (
             "Dear {{customer_id}},\n\n"
-            "Please find attached your account statement for "
-            "{{account_id}} covering {{period_start}} to {{period_end}}."
+            "We have added {{beneficiary_name}} (account "
+            "{{beneficiary_account}}, sort code {{sort_code}}) as a payee "
+            "on your account."
         ),
     },
-    "OPEN_DEPOSIT": {
-        "template_id": "tmpl-open-deposit-v1",
+    "REQUEST_CREDIT_LIMIT_INCREASE": {
+        "template_id": "tmpl-credit-limit-increase-v1",
         "required_fields": [
             "customer_id",
+            "card_id",
             "amount",
             "currency",
-            "term_months",
-            "payout_account",
+            "reason",
         ],
         "template_body": (
             "Dear {{customer_id}},\n\n"
-            "We have opened a deposit of {{amount}} {{currency}} "
-            "for {{term_months}} months. Payouts go to {{payout_account}}."
+            "We have received your request to increase the credit limit on "
+            "card {{card_id}} to {{amount}} {{currency}}. "
+            "Reason: {{reason}}."
         ),
     },
 }
 
 
 _FIELD_LABELS: dict[str, str] = {
-    "customer_id":    "Customer ID",
-    "account_id":     "Account ID",
-    "period_start":   "Statement start date",
-    "period_end":     "Statement end date",
-    "amount":         "Deposit amount",
-    "currency":       "Currency",
-    "term_months":    "Term (months)",
-    "payout_account": "Payout account",
+    "customer_id":         "Customer ID",
+    "beneficiary_name":    "Beneficiary name",
+    "beneficiary_account": "Beneficiary account number",
+    "sort_code":           "Sort code",
+    "card_id":             "Card ID",
+    "amount":              "Requested credit limit",
+    "currency":            "Currency",
+    "reason":              "Reason for request",
 }
 
 
@@ -160,8 +162,8 @@ def lookup_customer_email(
 # ---------------------------------------------------------------------------
 
 _SUBJECT_LABELS: dict[str, str] = {
-    "tmpl-account-statement-v1": "Your Account Statement",
-    "tmpl-open-deposit-v1": "Your Deposit Confirmation",
+    "tmpl-add-beneficiary-v1": "New Payee Added",
+    "tmpl-credit-limit-increase-v1": "Your Credit Limit Increase Request",
 }
 
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")

--- a/agent_app/e2e-chatbot-app-next/README.md
+++ b/agent_app/e2e-chatbot-app-next/README.md
@@ -340,7 +340,7 @@ The `chat` table (`packages/db/src/schema.ts`) has three columns beyond the upst
 | Column | Type | Purpose |
 |---|---|---|
 | `stage` | `varchar(64)` | Current workflow stage (e.g. `EXTRACT_FIELDS`, `DONE`) |
-| `intent` | `varchar(128)` | Classified banking intent (`GENERATE_ACCOUNT_STATEMENT` or `OPEN_DEPOSIT`) |
+| `intent` | `varchar(128)` | Classified banking intent (`ADD_BENEFICIARY` or `REQUEST_CREDIT_LIMIT_INCREASE`) |
 | `customerName` | `varchar(256)` | Customer identifier extracted during the workflow |
 
 After any schema change, regenerate and apply migrations:
@@ -356,11 +356,11 @@ Two components are customized to surface workflow state:
 
 **Filter bar** (`client/src/components/sidebar-history.tsx`): adds three controls above the chat list:
 - **Status toggle** — filter by **Open** (in-progress), **Waiting** (awaiting background check), **Received** (background check result ready), or deselect for all
-- **Intent dropdown** — filter by "Account Statement" or "Open Deposit"
+- **Intent dropdown** — filter by "Add Beneficiary" or "Credit Limit Increase"
 - **Customer search** — free-text substring search on customer name
 
 **Workflow badges** (`client/src/components/sidebar-history-item.tsx`): displayed under each chat title, showing:
-- Intent label (e.g. "Statement", "Deposit")
+- Intent label (e.g. "Beneficiary", "Credit Limit")
 - Step progress (e.g. "3/8") or terminal status: **Done**, **Waiting** (pulse animation), **Received**, **Denied**, or **Error**
 - Customer name (truncated)
 
@@ -371,7 +371,7 @@ Two components are customized to surface workflow state:
 | Parameter | Values | Description |
 |---|---|---|
 | `status` | `open`, `waiting`, `received`, `all` | Filter by workflow status (`open` = in-progress, `waiting` = awaiting background check, `received` = result ready) |
-| `intent` | e.g. `GENERATE_ACCOUNT_STATEMENT` | Filter by classified intent |
+| `intent` | e.g. `ADD_BENEFICIARY` | Filter by classified intent |
 | `customer` | free text | Substring search on customer name (case-insensitive) |
 
 ### Internal webhook
@@ -388,9 +388,9 @@ The following files contain the banking-assistant branding and copy — swap the
 
 | File | Customization |
 |---|---|
-| `client/src/components/app-sidebar.tsx` | Sidebar header: "Private Banking Assistant" |
-| `client/src/components/greeting.tsx` | Greeting: "Which private banking action can I support you with today?" |
-| `client/src/components/suggested-actions.tsx` | Suggested actions: "Open Deposit", "Generate Account Statement" |
+| `client/src/components/app-sidebar.tsx` | Sidebar header: "Banking Assistant" |
+| `client/src/components/greeting.tsx` | Greeting: "Which banking action can I support you with today?" |
+| `client/src/components/suggested-actions.tsx` | Suggested actions: "Request a credit limit increase", "Add a new beneficiary" |
 
 ## Known limitations
 

--- a/agent_app/e2e-chatbot-app-next/client/src/components/app-sidebar.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/app-sidebar.tsx
@@ -39,7 +39,7 @@ export function AppSidebar({
               className="flex flex-row items-center gap-3"
             >
               <span className="cursor-pointer rounded-md px-2 font-semibold text-lg hover:bg-muted">
-                Private Banking Assistant
+                Banking Assistant
               </span>
             </Link>
             <Tooltip>

--- a/agent_app/e2e-chatbot-app-next/client/src/components/greeting.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/greeting.tsx
@@ -22,7 +22,7 @@ export const Greeting = () => {
         transition={{ delay: 0.6 }}
         className="text-xl text-zinc-500 md:text-2xl"
       >
-        Which private banking action can I support you with today?
+        Which banking action can I support you with today?
       </motion.div>
     </div>
   );

--- a/agent_app/e2e-chatbot-app-next/client/src/components/sidebar-history-item.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/sidebar-history-item.tsx
@@ -46,8 +46,8 @@ const STAGE_STEP: Record<string, number> = {
 const TOTAL_STEPS = 8;
 
 const INTENT_LABELS: Record<string, string> = {
-  GENERATE_ACCOUNT_STATEMENT: 'Statement',
-  OPEN_DEPOSIT: 'Deposit',
+  ADD_BENEFICIARY: 'Beneficiary',
+  REQUEST_CREDIT_LIMIT_INCREASE: 'Credit Limit',
 };
 
 function WorkflowBadges({ chat }: { chat: Chat }) {

--- a/agent_app/e2e-chatbot-app-next/client/src/components/sidebar-history.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/sidebar-history.tsx
@@ -51,8 +51,8 @@ type StatusFilter = 'open' | 'waiting' | 'received' | 'all';
 
 const INTENT_OPTIONS = [
   { value: '', label: 'All intents' },
-  { value: 'GENERATE_ACCOUNT_STATEMENT', label: 'Account Statement' },
-  { value: 'OPEN_DEPOSIT', label: 'Open Deposit' },
+  { value: 'ADD_BENEFICIARY', label: 'Add Beneficiary' },
+  { value: 'REQUEST_CREDIT_LIMIT_INCREASE', label: 'Credit Limit Increase' },
 ];
 
 interface FilterState {

--- a/agent_app/e2e-chatbot-app-next/client/src/components/suggested-actions.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/suggested-actions.tsx
@@ -17,8 +17,8 @@ function PureSuggestedActions({ chatId, sendMessage }: SuggestedActionsProps) {
   const { chatHistoryEnabled } = useAppConfig();
   const suggestedActions = [
     'How can you help me?',
-    'Open Deposit',
-    'Generate Account Statement',
+    'Request a credit limit increase',
+    'Add a new beneficiary',
   ];
 
   return (


### PR DESCRIPTION
## What

Defines the reference demo's two intents:

- **`ADD_BENEFICIARY`** — collects `customer_id`, `beneficiary_name`, `beneficiary_account`, `sort_code`; the async human-in-the-loop background check models payee fraud screening.
- **`REQUEST_CREDIT_LIMIT_INCREASE`** — collects `customer_id`, `card_id`, `amount`, `currency`, `reason`; the async background check models a credit check.

The deterministic 8-stage graph and the async-HIL flow are **unchanged** — this is purely the intent definitions, required fields, email templates, and copy.

## Changes
- `tools_stubs.py` — intent templates, field labels, email subjects, classification keywords
- `langgraph_agent.py` — intent labels, classification prompt, stage-guard tuple, capability copy
- `dev_smoke_test.py` — smoke tests covering both intents end-to-end
- Frontend — intent filter dropdown, history badges, suggested actions; greeting + sidebar header copy
- `README.md`, `agent_server/README.md`, e2e `README.md` — intent docs

## Verification
- All 10 in-process smoke tests pass
- Verified locally (full UI + backend) and on the deployed Databricks App — both intents classify and progress through template-load → field-collection end-to-end

This pull request and its description were written by Isaac.